### PR TITLE
Update serve.yml

### DIFF
--- a/.github/workflows/serve.yml
+++ b/.github/workflows/serve.yml
@@ -40,5 +40,7 @@ jobs:
         with:
           distribution-id: ${{ secrets.CFDistributionId }}
           aws-region: 'us-east-1'
+          origin-prefix: ''
+          include-origin-prefix: false
           invalidate-paths: '/*'
           default-root-object: 'index.html'


### PR DESCRIPTION
serve.yml action "invalidate cloudfront cache" required a field  without the docs saying so. (nonexistent docs so w.e)